### PR TITLE
Fixed warning regarding not yet available setup.bash in user folder

### DIFF
--- a/src/ros2-workspace/.devcontainer/Dockerfile
+++ b/src/ros2-workspace/.devcontainer/Dockerfile
@@ -24,9 +24,19 @@ USER $USERNAME
 RUN mkdir -p /home/$USERNAME/ros2_ws/src
 WORKDIR /home/$USERNAME/ros2_ws
 
-# Copy configuration files
-RUN echo 'source /opt/ros/'$ROS_DISTRO'/setup.bash' >> /home/$USERNAME/.bashrc \
-    && echo 'source /home/'$USERNAME'/ros2_ws/install/setup.bash' >> /home/$USERNAME/.bashrc
+# Setup bashrc
+## Make ros2 public to the system via `source` command
+RUN echo 'source /opt/ros/'$ROS_DISTRO'/setup.bash' >> /home/$USERNAME/.bashrc
+
+## Check if own build have been made; if yes, source it 
+RUN cat << 'EOF' >> ~/.bashrc
+if [ -d "/home/'$USERNAME'/ros2_ws/install" ]; then
+    # Make own  public to the system via `source`
+    source /home/'$USERNAME'/ros2_ws/install/setup.bash
+else
+    echo "/home/$USERNAME/ros2_ws/install has not yet been created."
+fi
+EOF
 
 # Setup entrypoint
 COPY ./ros_entrypoint.sh /

--- a/src/ros2-workspace/.devcontainer/Dockerfile
+++ b/src/ros2-workspace/.devcontainer/Dockerfile
@@ -1,4 +1,5 @@
-FROM ros:${templateOption:distro}-${templateOption:imageVariant}
+FROM ros:humble-ros-base 
+# ${templateOption:distro}-${templateOption:imageVariant}
 
 ARG USERNAME=rosdev
 ARG UID=1000
@@ -26,7 +27,7 @@ WORKDIR /home/$USERNAME/ros2_ws
 
 # Setup bashrc
 ## Make ros2 public to the system via `source` command
-RUN echo 'source /opt/ros/'$ROS_DISTRO'/setup.bash' >> /home/$USERNAME/.bashrc
+RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> /home/$USERNAME/.bashrc
 
 ## Check if own build have been made; if yes, source it 
 RUN echo "if [ -d \"/home/$USERNAME/ros2_ws/install\" ]; then" >> /home/$USERNAME/.bashrc \
@@ -34,7 +35,7 @@ RUN echo "if [ -d \"/home/$USERNAME/ros2_ws/install\" ]; then" >> /home/$USERNAM
     && echo "else" >> /home/$USERNAME/.bashrc \
     && echo "    echo \"/home/$USERNAME/ros2_ws/install has not yet been created.\"" >> /home/$USERNAME/.bashrc \
     && echo "fi" >> /home/$USERNAME/.bashrc
-
+    
 # Setup entrypoint
 COPY ./ros_entrypoint.sh /
 ENTRYPOINT ["/ros_entrypoint.sh"]

--- a/src/ros2-workspace/.devcontainer/Dockerfile
+++ b/src/ros2-workspace/.devcontainer/Dockerfile
@@ -28,11 +28,11 @@ WORKDIR /home/$USERNAME/ros2_ws
 ## Make ros2 public to the system via `source` command
 RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> /home/$USERNAME/.bashrc
 
-## Check if own build have been made; if yes, source it 
-RUN echo "if [ -d \"/home/$USERNAME/ros2_ws/install\" ]; then" >> /home/$USERNAME/.bashrc \
+## Check if own build has been made; if yes, source it 
+RUN echo "if [ -f \"/home/$USERNAME/ros2_ws/install/setup.bash\" ]; then" >> /home/$USERNAME/.bashrc \
     && echo "    source /home/$USERNAME/ros2_ws/install/setup.bash" >> /home/$USERNAME/.bashrc \
     && echo "else" >> /home/$USERNAME/.bashrc \
-    && echo "    echo \"/home/$USERNAME/ros2_ws/install has not yet been created.\"" >> /home/$USERNAME/.bashrc \
+    && echo "    echo \"/home/$USERNAME/ros2_ws/install/setup.bash has not yet been created. Make sure to build your package(s).\"" >> /home/$USERNAME/.bashrc \
     && echo "fi" >> /home/$USERNAME/.bashrc
     
 # Setup entrypoint

--- a/src/ros2-workspace/.devcontainer/Dockerfile
+++ b/src/ros2-workspace/.devcontainer/Dockerfile
@@ -32,7 +32,8 @@ RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> /home/$USERNAME/.bashrc
 RUN echo "if [ -f \"/home/$USERNAME/ros2_ws/install/setup.bash\" ]; then" >> /home/$USERNAME/.bashrc \
     && echo "    source /home/$USERNAME/ros2_ws/install/setup.bash" >> /home/$USERNAME/.bashrc \
     && echo "else" >> /home/$USERNAME/.bashrc \
-    && echo "    echo \"/home/$USERNAME/ros2_ws/install/setup.bash has not yet been created. Make sure to build your package(s).\"" >> /home/$USERNAME/.bashrc \
+    && echo "    echo \"/home/$USERNAME/ros2_ws/install/setup.bash has not yet been created.\"" >> /home/$USERNAME/.bashrc \
+    && echo "    echo \"Make sure to build your package(s).\"" >> /home/$USERNAME/.bashrc \
     && echo "fi" >> /home/$USERNAME/.bashrc
     
 # Setup entrypoint

--- a/src/ros2-workspace/.devcontainer/Dockerfile
+++ b/src/ros2-workspace/.devcontainer/Dockerfile
@@ -29,14 +29,11 @@ WORKDIR /home/$USERNAME/ros2_ws
 RUN echo 'source /opt/ros/'$ROS_DISTRO'/setup.bash' >> /home/$USERNAME/.bashrc
 
 ## Check if own build have been made; if yes, source it 
-RUN cat << 'EOF' >> ~/.bashrc
-if [ -d "/home/'$USERNAME'/ros2_ws/install" ]; then
-    # Make own  public to the system via `source`
-    source /home/'$USERNAME'/ros2_ws/install/setup.bash
-else
-    echo "/home/$USERNAME/ros2_ws/install has not yet been created."
-fi
-EOF
+RUN echo "if [ -d \"/home/$USERNAME/ros2_ws/install\" ]; then" >> /home/$USERNAME/.bashrc \
+    && echo "    source /home/$USERNAME/ros2_ws/install/setup.bash" >> /home/$USERNAME/.bashrc \
+    && echo "else" >> /home/$USERNAME/.bashrc \
+    && echo "    echo \"/home/$USERNAME/ros2_ws/install has not yet been created.\"" >> /home/$USERNAME/.bashrc \
+    && echo "fi" >> /home/$USERNAME/.bashrc
 
 # Setup entrypoint
 COPY ./ros_entrypoint.sh /

--- a/src/ros2-workspace/.devcontainer/Dockerfile
+++ b/src/ros2-workspace/.devcontainer/Dockerfile
@@ -1,5 +1,4 @@
-FROM ros:humble-ros-base 
-# ${templateOption:distro}-${templateOption:imageVariant}
+FROM ros:${templateOption:distro}-${templateOption:imageVariant}
 
 ARG USERNAME=rosdev
 ARG UID=1000


### PR DESCRIPTION
A notification message will be displayed instead of the warning that the `source` execution is not possible.
After the local packages are created, the folder will be found and *setup.bash* will be sourced.